### PR TITLE
Fragment type: oneof

### DIFF
--- a/src/command/new_command.rs
+++ b/src/command/new_command.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 
 use dialoguer::Confirm;
 use dialoguer::Input;
+use dialoguer::Select;
 
 use crate::cli::TextProvider;
 use crate::cli::KV;
@@ -18,6 +19,7 @@ use crate::fragment::Crawler;
 use crate::fragment::FragmentData;
 use crate::fragment::FragmentDataDesc;
 use crate::fragment::FragmentDataType;
+use crate::fragment::FragmentDataTypeDefinite;
 
 #[derive(Debug, typed_builder::TypedBuilder)]
 pub struct NewCommand {
@@ -269,7 +271,7 @@ fn interactive_provide(
     desc: &FragmentDataDesc,
 ) -> Result<Option<(String, FragmentData)>, InteractiveError> {
     match desc.fragment_type() {
-        FragmentDataType::Bool => {
+        FragmentDataType::Ty(FragmentDataTypeDefinite::Bool) => {
             let mut dialoguer = Confirm::new();
             dialoguer.with_prompt(format!("'{}'?", key));
             if let Some(data) = desc.default_value() {
@@ -295,7 +297,7 @@ fn interactive_provide(
 
             Ok(Some((key.to_string(), FragmentData::Bool(value))))
         }
-        FragmentDataType::Int => {
+        FragmentDataType::Ty(FragmentDataTypeDefinite::Int) => {
             let mut dialoguer = Input::<u64>::new();
             dialoguer.with_prompt(format!("Enter a number for '{}'", key));
 
@@ -313,7 +315,7 @@ fn interactive_provide(
             let value = dialoguer.interact_text().map_err(InteractiveError::from)?;
             Ok(Some((key.to_string(), FragmentData::Int(value))))
         }
-        FragmentDataType::Str => {
+        FragmentDataType::Ty(FragmentDataTypeDefinite::Str) => {
             let mut dialoguer = Input::<String>::new();
             dialoguer.with_prompt(format!("Enter a text for '{}'", key));
 
@@ -330,6 +332,38 @@ fn interactive_provide(
 
             let value = dialoguer.interact_text().map_err(InteractiveError::from)?;
             Ok(Some((key.to_string(), FragmentData::Str(value))))
+        }
+        FragmentDataType::OneOf(possible_values) => {
+            let mut dialoguer = Select::new();
+            dialoguer.items(possible_values);
+            dialoguer.with_prompt("Select one");
+
+            if let Some(default_value) = desc.default_value() {
+                if let FragmentData::Str(default_value) = default_value {
+                    if let Some(default_idx) = possible_values
+                        .iter()
+                        .enumerate()
+                        .find(|(_, elmt)| *elmt == default_value)
+                        .map(|(i, _)| i)
+                    {
+                        dialoguer.default(default_idx);
+                    }
+                } else {
+                    return Err(InteractiveError::TypeError(
+                        desc.fragment_type().clone(),
+                        default_value.clone(),
+                    ));
+                }
+            }
+
+            let value_idx = dialoguer.interact().map_err(InteractiveError::from)?;
+            let value = possible_values
+                .get(value_idx)
+                .ok_or_else(|| InteractiveError::IndexError(value_idx, possible_values.len()))?;
+            Ok(Some((
+                key.to_string(),
+                FragmentData::Str(value.to_string()),
+            )))
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -150,4 +150,7 @@ pub enum InteractiveError {
 
     #[error("Failed to parse intefer")]
     ParseInt(#[from] std::num::ParseIntError),
+
+    #[error("Index error: Tried to select entry {}, but list has only {}", .0, .1)]
+    IndexError(usize, usize),
 }

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -186,7 +186,14 @@ impl FragmentDataType {
             FragmentDataType::Ty(FragmentDataTypeDefinite::Bool) => "bool".to_string(),
             FragmentDataType::Ty(FragmentDataTypeDefinite::Int) => "int".to_string(),
             FragmentDataType::Ty(FragmentDataTypeDefinite::Str) => "string".to_string(),
-            FragmentDataType::OneOf { .. } => "oneof".to_string(),
+            FragmentDataType::OneOf(list) => {
+                let list = list
+                    .iter()
+                    .map(|el| format!("'{}'", el))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("one of: {}", list)
+            }
         }
     }
 


### PR DESCRIPTION
This introduces a "OneOf" fragment type, which can be used to represent some kind of "enum" in a fragment, which has to have one of a set of possible values.