### PR TITLE
Group by helper

### DIFF
--- a/assets/default_config.toml
+++ b/assets/default_config.toml
@@ -118,3 +118,10 @@ required = true
 #value = "scripts/fetch_issue_number.sh"
 #value = "some command to execute with arguments"
 
+# A header field named "type"
+# With three possible values: "Bugfix", "Feature" or "Misc"
+# which is required
+[header_fields.type]
+type = [ "Bugfix", "Feature", "Misc" ]
+required = true
+

--- a/assets/default_template.handlebars.md
+++ b/assets/default_template.handlebars.md
@@ -6,11 +6,14 @@
 {{#each (reverse (sort_versions this.versions))}}
 ## v{{this.version}}
 
-{{#each this.entries}}
-### (#{{this.header.issue}}) {{this.header.subject}}
+{{#each (group_by_header this.entries "type")}}
+### {{ @key }}
+
+{{#each this}}
+#### (#{{this.header.issue}}) {{this.header.subject}}
 
 {{this.text}}
-
+{{/each}}
 {{/each}}
 
 {{/each}}

--- a/src/command/release_command.rs
+++ b/src/command/release_command.rs
@@ -211,6 +211,7 @@ mod tests {
                     {
                         let mut hdr = HashMap::new();
                         hdr.insert("issue".to_string(), FragmentData::Int(123));
+                        hdr.insert("type".to_string(), FragmentData::Str("Bugfix".to_string()));
                         hdr
                     },
                     "test for 0.1.0".to_string(),
@@ -246,6 +247,7 @@ mod tests {
                     {
                         let mut hdr = HashMap::new();
                         hdr.insert("issue".to_string(), FragmentData::Int(123));
+                        hdr.insert("type".to_string(), FragmentData::Str("Bugfix".to_string()));
                         hdr
                     },
                     "test for 0.1.0".to_string(),
@@ -276,6 +278,7 @@ mod tests {
                         {
                             let mut hdr = HashMap::new();
                             hdr.insert("issue".to_string(), FragmentData::Int(123));
+                            hdr.insert("type".to_string(), FragmentData::Str("Bugfix".to_string()));
                             hdr
                         },
                         "test for 0.1.0".to_string(),
@@ -287,6 +290,10 @@ mod tests {
                         {
                             let mut hdr = HashMap::new();
                             hdr.insert("issue".to_string(), FragmentData::Int(234));
+                            hdr.insert(
+                                "type".to_string(),
+                                FragmentData::Str("Feature".to_string()),
+                            );
                             hdr
                         },
                         "test for 0.2.0".to_string(),

--- a/src/template/common.rs
+++ b/src/template/common.rs
@@ -1,0 +1,12 @@
+use serde_json::Value;
+
+pub fn json_type_name(json: &Value) -> &'static str {
+    match json {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}

--- a/src/template/group_by_helper.rs
+++ b/src/template/group_by_helper.rs
@@ -1,0 +1,75 @@
+use handlebars::{Context, Handlebars, Helper, HelperDef, RenderContext, RenderError, ScopedJson};
+
+use itertools::Itertools;
+use serde_json::Value;
+
+#[derive(Clone, Copy)]
+pub struct GroupByHelper;
+
+impl HelperDef for GroupByHelper {
+    fn call_inner<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'reg, 'rc>,
+        _: &'reg Handlebars<'reg>,
+        _: &'rc Context,
+        _: &mut RenderContext<'reg, 'rc>,
+    ) -> Result<handlebars::ScopedJson<'reg, 'rc>, RenderError> {
+        let group_by_attr = h
+            .param(1)
+            .map(|p| p.value())
+            .ok_or_else(|| {
+                RenderError::new(format!(
+                    "Insufficient arguments, expected two, got {}",
+                    h.params().len()
+                ))
+            })?
+            .as_str()
+            .ok_or_else(|| RenderError::new("Expected String as key to group by".to_string()))?;
+
+        match h.param(0).map(|p| p.value()) {
+            None => Err(RenderError::new(format!(
+                "Insufficient arguments, expected two, got {}",
+                h.params().len()
+            ))),
+            Some(Value::Array(list)) => {
+                let mut res: serde_json::Map<String, _> = serde_json::Map::new();
+
+                let object_list = list
+                    .into_iter()
+                    .map(|elt| match elt {
+                        serde_json::Value::Object(map) => {
+                            Ok(serde_json::Value::Object(map.clone()))
+                        }
+                        other => Err(RenderError::new(format!(
+                            "At least one of the elements is not an object, but a {}",
+                            crate::template::common::json_type_name(&other)
+                        ))),
+                    })
+                    .collect::<Result<Vec<serde_json::Value>, RenderError>>()?;
+
+                for (group, list) in object_list
+                    .into_iter()
+                    .group_by(|elt: &serde_json::Value| {
+                        elt.get("header")
+                            .and_then(|hdr| hdr.get(&group_by_attr))
+                            .cloned()
+                    })
+                    .into_iter()
+                {
+                    let list = list.into_iter().collect();
+                    let group = group.ok_or_else(|| {
+                        RenderError::new(format!("Failed to group by '{}', not all elements in the list have that attribute! List: {:?}", group_by_attr, list))
+                    })?;
+
+                    res.insert(group.to_string(), serde_json::Value::Array(list));
+                }
+
+                Ok(ScopedJson::Derived(serde_json::Value::from(res)))
+            }
+            Some(other) => Err(RenderError::new(format!(
+                "Expected array as argument, got {}",
+                crate::template::common::json_type_name(other)
+            ))),
+        }
+    }
+}

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -2,6 +2,7 @@ use handlebars::Handlebars;
 
 use crate::error::Error;
 
+mod common;
 mod reverse_helper;
 mod sort_versions_helper;
 

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -3,6 +3,7 @@ use handlebars::Handlebars;
 use crate::error::Error;
 
 mod common;
+mod group_by_helper;
 mod reverse_helper;
 mod sort_versions_helper;
 
@@ -15,5 +16,9 @@ pub fn new_handlebars(template_source: &str) -> Result<Handlebars, Error> {
         Box::new(self::sort_versions_helper::sort_versions),
     );
     handlebars.register_helper("reverse", Box::new(self::reverse_helper::ReverseHelper));
+    handlebars.register_helper(
+        "group_by_header",
+        Box::new(self::group_by_helper::GroupByHelper),
+    );
     Ok(handlebars)
 }

--- a/src/template/reverse_helper.rs
+++ b/src/template/reverse_helper.rs
@@ -23,19 +23,8 @@ impl HelperDef for ReverseHelper {
             ))),
             Some(other) => Err(RenderError::new(format!(
                 "Expected array as argument, got {}",
-                json_type_name(other)
+                crate::template::common::json_type_name(other)
             ))),
         }
-    }
-}
-
-fn json_type_name(json: &Value) -> &'static str {
-    match json {
-        Value::Null => "null",
-        Value::Bool(_) => "bool",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
     }
 }

--- a/tests/generate_command.rs
+++ b/tests/generate_command.rs
@@ -44,6 +44,8 @@ fn generate_command_moves_from_unreleased_dir() {
             "issue=123",
             "--set",
             "subject='This is some text'",
+            "--set",
+            "type=Bugfix",
         ])
         .assert()
         .success();

--- a/tests/new_command.rs
+++ b/tests/new_command.rs
@@ -17,6 +17,8 @@ fn new_command_creates_yaml_file() {
             "issue=123",
             "--set",
             "subject=This is some text",
+            "--set",
+            "type=Bugfix",
         ])
         .assert()
         .success();
@@ -119,6 +121,8 @@ fn new_command_with_text_creates_yaml_with_text_from_stdin() {
                 "issue=123",
                 "--set",
                 "subject='This is some text'",
+                "--set",
+                "type=Bugfix",
                 "--read=-", // read text from STDIN
             ])
             .pipe_stdin(path)
@@ -177,6 +181,8 @@ fn new_command_with_text_creates_yaml_with_text_from_file() {
                 "issue=123",
                 "--set",
                 "subject='This is some text'",
+                "--set",
+                "type=Bugfix",
                 // read text from PATH
                 "--read",
                 &path.display().to_string(),
@@ -222,6 +228,8 @@ fn new_command_creates_toml_header() {
             "issue=123",
             "--set",
             "subject='This is some text'",
+            "--set",
+            "type=Bugfix",
         ])
         .assert()
         .success();
@@ -285,6 +293,8 @@ fn new_command_cannot_create_nonexistent_oneof() {
             "subject='This is some text'",
             "--set",
             "field=baz",
+            "--set",
+            "type=Bugfix",
         ])
         .assert()
         .failure();

--- a/tests/new_command_creates_default_header.rs
+++ b/tests/new_command_creates_default_header.rs
@@ -39,6 +39,8 @@ fn new_command_creates_default_header() {
             "number=345",
             "--set",
             "subject='This is some text'",
+            "--set",
+            "type=Misc",
         ])
         .assert()
         .success();

--- a/tests/new_command_editor.rs
+++ b/tests/new_command_editor.rs
@@ -72,6 +72,8 @@ fn new_command_opens_editor() {
             "issue=123",
             "--set",
             "subject='This is some text'",
+            "--set",
+            "type=Misc",
         ])
         .current_dir(&temp_dir)
         .assert()

--- a/tests/release_command.rs
+++ b/tests/release_command.rs
@@ -18,6 +18,8 @@ fn release_command_works() {
             "issue=123",
             "--set",
             "subject='Test subject'",
+            "--set",
+            "type=Misc",
         ])
         .assert()
         .success();
@@ -61,6 +63,8 @@ fn release_command_works_for_alpha_release() {
             "issue=123",
             "--set",
             "subject='Test subject'",
+            "--set",
+            "type=Misc",
         ])
         .assert()
         .success();

--- a/tests/verify_metadata_command.rs
+++ b/tests/verify_metadata_command.rs
@@ -29,6 +29,8 @@ fn verify_metadata_command_succeeds_with_empty_changelog() {
             "issue=123",
             "--set",
             "subject='test subject'",
+            "--set",
+            "type=Feature",
         ])
         .assert()
         .success();


### PR DESCRIPTION
This adds a group_by_header helper and adjusts the template so that fragments are now grouped by the "type" field from their headers.