### PR TITLE
Disallow release dirty

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,9 @@ pub enum Command {
         /// Also write "unreleased" stuff to the CHANGELOG.md file
         #[clap(long)]
         all: bool,
+
+        #[clap(long, default_value_t = false)]
+        allow_dirty: bool,
     },
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("git error")]
     Git(#[from] git2::Error),
 
+    #[error("Repository dirty")]
+    GitRepoDirty,
+
     #[error("TOML deserialization error")]
     Toml(#[from] toml::de::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod error;
 mod format;
 mod fragment;
 mod template;
+mod util;
 
 use crate::cli::Command;
 use crate::command::Command as _;

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,10 @@ fn main() -> miette::Result<()> {
             .build()
             .execute(&repo_workdir_path, &config)?,
 
-        Command::Release { all } => crate::command::ReleaseCommand::builder()
+        Command::Release { all, allow_dirty } => crate::command::ReleaseCommand::builder()
+            .repository(repository)
             .all(all)
+            .allow_dirty(allow_dirty)
             .build()
             .execute(&repo_workdir_path, &config)?,
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,24 @@
+use itertools::Itertools;
+
+pub fn repo_is_dirty(repo: &git2::Repository) -> bool {
+    if repo.state() != git2::RepositoryState::Clean {
+        log::trace!("Repository status is unclean: {:?}", repo.state());
+        return true;
+    }
+
+    let status = repo
+        .statuses(Some(git2::StatusOptions::new().include_ignored(false)))
+        .unwrap();
+    if status.is_empty() {
+        false
+    } else {
+        log::trace!(
+            "Repository is dirty: {}",
+            status
+                .iter()
+                .flat_map(|s| s.path().map(|s| s.to_owned()))
+                .join(", ")
+        );
+        true
+    }
+}


### PR DESCRIPTION
This adds a flag to the `release` subcommand to overwrite the is-repo-dirty check, which is also introduced in this PR.

---

Closes #82 