### PR TITLE
Fix: Change filename timestamp format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,14 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 serde_yaml = "0.9.13"
 thiserror = "1.0.35"
-time = { version = "0.3.14", features = [ "formatting" ] }
+time = { version = "0.3.14", features = [ "formatting", "macros" ] }
 toml = "0.5.9"
 typed-builder = "0.10.0"
 walkdir = "2.3.2"

--- a/src/command/new_command.rs
+++ b/src/command/new_command.rs
@@ -39,8 +39,13 @@ impl crate::command::Command for NewCommand {
             let new_file_name = format!(
                 "{ts}.md",
                 ts = {
-                    time::OffsetDateTime::now_utc()
-                        .format(&time::format_description::well_known::Iso8601::DEFAULT)?
+                    // We cannot use the well-known formats here, because cargo cannot package
+                    // filenames with ":" in it, but the well-known formats contain this character.
+                    // Hence we have to use our own.
+                    let fragment_file_timestamp_format = time::macros::format_description!(
+                        "[year]-[month]-[day]T[hour]_[minute]_[second]_[subsecond]"
+                    );
+                    time::OffsetDateTime::now_utc().format(&fragment_file_timestamp_format)?
                 },
             );
             unreleased_dir_path.join(new_file_name)


### PR DESCRIPTION
Backport the filename-timestamp-format fix to the release branch.