### PR TITLE
bors: Cut body after <details>

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,7 +3,7 @@ status = [
     "CI"
 ]
 
-cut_body_after = "---"
+cut_body_after = "<details>"
 
 delete_merged_branches = true
 


### PR DESCRIPTION
Because dependabot merges are way too noisy otherwise.
