### PR TITLE
Subcommand show

### DIFF
--- a/.changelogs/unreleased/2023-03-03T08_08_41_21078057.md
+++ b/.changelogs/unreleased/2023-03-03T08_08_41_21078057.md
@@ -1,0 +1,8 @@
+---
+subject: '"Show" subcommand'
+type: Feature
+
+---
+
+A "show" subcommand was added to print changelog fragments either as text or as
+JSON.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,7 +149,7 @@ impl TextProvider {
     }
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Clone, Debug, Subcommand)]
 pub enum VersionSpec {
     Patch,
     Minor,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,6 +85,13 @@ pub enum Command {
         #[clap(long, default_value_t = false)]
         allow_dirty: bool,
     },
+
+    Show {
+        #[clap(long)]
+        format: Option<ShowFormat>,
+        #[clap(subcommand)]
+        range: Option<ShowRange>,
+    },
 }
 
 fn text_provider_parser(s: &str) -> Result<TextProvider, String> {
@@ -158,4 +165,17 @@ pub enum VersionSpec {
         #[clap(value_parser)]
         custom: String,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
+pub enum ShowFormat {
+    Text,
+    Json,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum ShowRange {
+    Unreleased,
+    Exact { exact: String },
+    Range { from: String, until: String },
 }

--- a/src/command/common.rs
+++ b/src/command/common.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
 
-use crate::error::VersionError;
+use crate::{
+    cli::VersionSpec,
+    error::{Error, VersionError},
+};
 
 pub fn get_version_from_path(path: &Path) -> Result<Option<semver::Version>, VersionError> {
     path.components()
@@ -24,4 +27,36 @@ pub fn get_version_from_path(path: &Path) -> Result<Option<semver::Version>, Ver
             _ => None,
         })
         .transpose()
+}
+
+pub fn find_version_string(workdir: &Path, version: &VersionSpec) -> Result<String, Error> {
+    use cargo_metadata::MetadataCommand;
+
+    if let VersionSpec::Custom { custom } = version {
+        Ok(custom.clone())
+    } else {
+        let metadata = MetadataCommand::new()
+            .manifest_path(workdir.join("./Cargo.toml"))
+            .exec()?;
+
+        let workspace_member_ids = &metadata.workspace_members;
+
+        let versions = metadata
+            .packages
+            .iter()
+            .filter(|pkg| workspace_member_ids.contains(&pkg.id))
+            .map(|pkg| &pkg.version)
+            .collect::<Vec<_>>();
+
+        if versions.is_empty() {
+            return Err(Error::NoVersionInCargoToml);
+        }
+
+        let first = versions[0];
+        let all_versions_same = versions.iter().all(|v| *v == first);
+        if !all_versions_same {
+            return Err(Error::WorkspaceVersionsNotEqual);
+        }
+        Ok(first.to_string())
+    }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -14,6 +14,9 @@ mod release_command;
 pub use self::release_command::ReleaseCommand;
 pub use self::release_command::VersionData;
 
+mod show;
+pub use self::show::Show;
+
 mod verify_metadata_command;
 pub use self::verify_metadata_command::VerifyMetadataCommand;
 

--- a/src/command/show.rs
+++ b/src/command/show.rs
@@ -40,6 +40,7 @@ impl crate::command::Command for Show {
 
         let pathes = match self.range {
             None | Some(ShowRange::Unreleased) => {
+                log::debug!("Showing unreleased");
                 let unreleased_dir_path = workdir
                     .join(config.fragment_dir())
                     .join(crate::consts::UNRELEASED_DIR_NAME);
@@ -49,6 +50,7 @@ impl crate::command::Command for Show {
                     .collect::<Result<Vec<PathBuf>, Error>>()?
             }
             Some(ShowRange::Exact { exact }) => {
+                log::debug!("Showing exact {exact}");
                 let path = workdir.join(config.fragment_dir()).join(&exact);
                 if !path.exists() {
                     return Err(Error::ExactVersionDoesNotExist { version: exact });
@@ -59,6 +61,7 @@ impl crate::command::Command for Show {
                     .collect::<Result<Vec<PathBuf>, Error>>()?
             }
             Some(ShowRange::Range { from, until }) => {
+                log::debug!("Showing range from {from} until {until}");
                 let from = semver::Version::parse(&from)?;
                 let until = semver::Version::parse(&until)?;
 
@@ -92,6 +95,7 @@ impl crate::command::Command for Show {
             }
         };
 
+        log::trace!("Looking at: {pathes:?}");
         let fragments = pathes.into_iter().map(|path| {
             std::fs::OpenOptions::new()
                 .read(true)

--- a/src/command/show.rs
+++ b/src/command/show.rs
@@ -1,0 +1,139 @@
+use std::{
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    cli::{ShowFormat, ShowRange},
+    config::Configuration,
+    error::{Error, FragmentError},
+    fragment::Fragment,
+};
+
+#[derive(Debug, typed_builder::TypedBuilder)]
+pub struct Show {
+    format: Option<crate::cli::ShowFormat>,
+    range: Option<ShowRange>,
+}
+
+impl crate::command::Command for Show {
+    fn execute(self, workdir: &Path, config: &Configuration) -> Result<(), Error> {
+        let walk_dir = |path| {
+            walkdir::WalkDir::new(path)
+                .follow_links(false)
+                .max_open(100)
+                .same_file_system(true)
+                .into_iter()
+        };
+
+        let result_dir_entry_to_pathbuf = |rde: Result<walkdir::DirEntry, _>| match rde {
+            Ok(de) => de.path().is_file().then(|| de.path().to_path_buf()).map(Ok),
+            Err(e) => Some(Err(Error::from(e))),
+        };
+
+        let is_gitkeep = |rpath: &Result<PathBuf, _>| match rpath {
+            Ok(path) => path.ends_with(".gitkeep"),
+            Err(_) => true,
+        };
+
+        let pathes = match self.range {
+            None | Some(ShowRange::Unreleased) => {
+                let unreleased_dir_path = workdir
+                    .join(config.fragment_dir())
+                    .join(crate::consts::UNRELEASED_DIR_NAME);
+                walk_dir(unreleased_dir_path)
+                    .filter_map(result_dir_entry_to_pathbuf)
+                    .filter(|r| !is_gitkeep(r))
+                    .collect::<Result<Vec<PathBuf>, Error>>()?
+            }
+            Some(ShowRange::Exact { exact }) => {
+                let path = workdir.join(config.fragment_dir()).join(&exact);
+                if !path.exists() {
+                    return Err(Error::ExactVersionDoesNotExist { version: exact });
+                }
+                walk_dir(path)
+                    .filter_map(result_dir_entry_to_pathbuf)
+                    .filter(|r| !is_gitkeep(r))
+                    .collect::<Result<Vec<PathBuf>, Error>>()?
+            }
+            Some(ShowRange::Range { from, until }) => {
+                let from = semver::Version::parse(&from)?;
+                let until = semver::Version::parse(&until)?;
+
+                let fragment_dir_path = workdir.join(config.fragment_dir());
+                walk_dir(fragment_dir_path)
+                    .filter_entry(|de| {
+                        log::debug!("Looking at {de:?}");
+                        if de.path().is_dir() {
+                            true
+                        } else if de.path().is_file() {
+                            de.path().components().any(|comp| match comp {
+                                std::path::Component::Normal(osstr) => osstr
+                                    .to_str()
+                                    .map(|s| {
+                                        if let Ok(version) = semver::Version::parse(s) {
+                                            version > from && version < until
+                                        } else {
+                                            false
+                                        }
+                                    })
+                                    .unwrap_or(false),
+                                _ => false,
+                            })
+                        } else {
+                            false
+                        }
+                    })
+                    .filter_map(result_dir_entry_to_pathbuf)
+                    .filter(|r| !is_gitkeep(r))
+                    .collect::<Result<Vec<PathBuf>, Error>>()?
+            }
+        };
+
+        let fragments = pathes.into_iter().map(|path| {
+            std::fs::OpenOptions::new()
+                .read(true)
+                .create(false)
+                .write(false)
+                .open(&path)
+                .map_err(FragmentError::from)
+                .map(BufReader::new)
+                .and_then(|mut reader| {
+                    Fragment::from_reader(&mut reader).map(|f| (path.to_path_buf(), f))
+                })
+                .map_err(|e| Error::FragmentError(e, path.to_path_buf()))
+        });
+
+        match self.format {
+            None | Some(ShowFormat::Text) => pretty_print(fragments),
+            Some(ShowFormat::Json) => json_print(fragments),
+        }
+    }
+}
+
+fn pretty_print(
+    mut iter: impl Iterator<Item = Result<(PathBuf, Fragment), Error>>,
+) -> Result<(), Error> {
+    use std::io::Write;
+
+    let out = std::io::stdout();
+    let mut output = out.lock();
+
+    iter.try_for_each(|fragment| {
+        let (path, fragment) = fragment?;
+        writeln!(output, "{}", path.display())?;
+        fragment.header().iter().try_for_each(|(key, value)| {
+            writeln!(output, "{key}: {value}", value = value.display())?;
+            Ok(()) as Result<(), Error>
+        })?;
+
+        writeln!(output, "{text}", text = fragment.text())?;
+        Ok(())
+    })
+}
+
+fn json_print(
+    _iter: impl Iterator<Item = Result<(PathBuf, Fragment), Error>>,
+) -> Result<(), Error> {
+    unimplemented!()
+}

--- a/src/command/show.rs
+++ b/src/command/show.rs
@@ -1,5 +1,7 @@
 use std::{
+    collections::HashMap,
     io::BufReader,
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -114,8 +116,6 @@ impl crate::command::Command for Show {
 fn pretty_print(
     mut iter: impl Iterator<Item = Result<(PathBuf, Fragment), Error>>,
 ) -> Result<(), Error> {
-    use std::io::Write;
-
     let out = std::io::stdout();
     let mut output = out.lock();
 
@@ -132,8 +132,9 @@ fn pretty_print(
     })
 }
 
-fn json_print(
-    _iter: impl Iterator<Item = Result<(PathBuf, Fragment), Error>>,
-) -> Result<(), Error> {
-    unimplemented!()
+fn json_print(iter: impl Iterator<Item = Result<(PathBuf, Fragment), Error>>) -> Result<(), Error> {
+    let v = iter.collect::<Result<HashMap<PathBuf, Fragment>, _>>()?;
+    let out = std::io::stdout();
+    let output = out.lock();
+    serde_json::to_writer(output, &v).map_err(Error::from)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,9 @@ pub enum Error {
     #[error("Fragment Error: {}", .1.display())]
     FragmentError(#[source] FragmentError, PathBuf),
 
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
     #[error("Version error")]
     Version(#[from] VersionError),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
     #[error("Environment variable '{0}' is not unicode")]
     EnvNotUnicode(String),
 
+    #[error("Specified version '{version}' does not exist")]
+    ExactVersionDoesNotExist { version: String },
+
     #[error(transparent)]
     SemVer(#[from] semver::Error),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
     #[error("Environment variable '{0}' is not unicode")]
     EnvNotUnicode(String),
 
+    #[error(transparent)]
+    SemVer(#[from] semver::Error),
+
     #[error("Fragment Error: {}", .1.display())]
     FragmentError(#[source] FragmentError, PathBuf),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,12 @@ fn main() -> miette::Result<()> {
             .allow_dirty(allow_dirty)
             .build()
             .execute(&repo_workdir_path, &config)?,
+
+        Command::Show { format, range } => crate::command::Show::builder()
+            .format(format)
+            .range(range)
+            .build()
+            .execute(&repo_workdir_path, &config)?,
     }
 
     Ok(())


### PR DESCRIPTION
Partly solves #202 

@thomaseizinger Please have a look at this PR. It might help you solving your problem from #202.

This PR introduces a "show" subcommand, which can be used to print information about the existing changelog entries. It currently features only a "text" backend, but it is prepared to implement also a "json" backend, which then could be used to process the structured data from a changelog.

<details>
Marked as draft because there's still `unimplemented!()` stuff in there.
</details>