### PR TITLE
Make cargo-deny optional in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
       - check
       - nix-checks
       - clippy
-      - deny
       - fmt
       - test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rationale being that this might break unrelated PRs, which is really not what we want.