### PR TITLE
build(deps): bump typed-builder from 0.12.0 to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6179333b981641242a768f30f371c9baccbfcc03749627000c500ab88bf4528b"
+checksum = "64cba322cb9b7bc6ca048de49e83918223f35e7a86311267013afff257004870"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = "0.9.17"
 thiserror = "1.0.38"
 time = { version = "0.3.20", features = [ "formatting", "macros" ] }
 toml = "0.7.3"
-typed-builder = "0.12.0"
+typed-builder = "0.14.0"
 walkdir = "2.3.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Supersedes #216 
Closes #216 

---

Bumps [typed-builder](https://github.com/idanarye/rust-typed-builder) from 0.12.0 to 0.14.0.
- [Release notes](https://github.com/idanarye/rust-typed-builder/releases)
- [Changelog](https://github.com/idanarye/rust-typed-builder/blob/master/CHANGELOG.md)
- [Commits](https://github.com/idanarye/rust-typed-builder/commits)

---
updated-dependencies:
- dependency-name: typed-builder dependency-type: direct:production update-type: version-update:semver-minor ...