### PR TITLE
Feature/rename subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It works in the following way:
 
 - Everytime you add/change/fix something and want to document it, you create a
   new changelog entry with `cargo changelog add`
-- Then, when a new version is released, you run `cargo changelog generate
+- Then, when a new version is released, you run `cargo changelog create-release
   <bump>` to move all unreleased changes to either the next patch/minor/major
   version
 - Finally, you re-generate the CHANGELOG.md file using `cargo changelog release`
@@ -44,13 +44,13 @@ If interactive mode is enabled, which it is per-default, then you will be
 prompted to fill in the fields of the changelog as well as a larger free-form
 entry where you can explain the motivation and consequences of the changes.
 
-### cargo changelog generate <bump>
+### cargo changelog create-release <bump>
 
-Once you are done with one release, `cargo-changelog generate <version>` (for
-example `cargo changelog generate minor` for the next minor version) will take
-all unreleased changelogs and move them to `/.changelogs/0.1.0` (if "0.1.0" is
-your next minor version - you can of course also specify an explicit version
-with the `generate` subcommand).
+Once you are done with one release, `cargo-changelog create-release <version>`
+(for example `cargo changelog create-release minor` for the next minor version)
+will take all unreleased changelogs and move them to `/.changelogs/0.1.0` (if
+"0.1.0" is your next minor version - you can of course also specify an explicit
+version with the `create-release` subcommand).
 
 ### cargo changelog release
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ will take all unreleased changelogs and move them to `/.changelogs/0.1.0` (if
 "0.1.0" is your next minor version - you can of course also specify an explicit
 version with the `create-release` subcommand).
 
-### cargo changelog release
+### cargo changelog generate-changelog
 
 After that you can create your final `CHANGELOG.md` file using
-`cargo-changelog release`.
+`cargo-changelog generate-changelog`
 
 This will take all released changelog entries and generate a new file,
 overwriting the old.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ seamlessly integrate with the generated one.
 It works in the following way:
 
 - Everytime you add/change/fix something and want to document it, you create a
-  new changelog entry with `cargo changelog new`
+  new changelog entry with `cargo changelog add`
 - Then, when a new version is released, you run `cargo changelog generate
   <bump>` to move all unreleased changes to either the next patch/minor/major
   version
@@ -36,9 +36,9 @@ It works in the following way:
 
 Here's how they work individually:
 
-### cargo changelog new
+### cargo changelog add
 
-`cargo changelog new` generates a new changelog file in the unreleased
+`cargo changelog add` generates a new changelog file in the unreleased
 changelog directory. Per default that is `.changelogs/unreleased`.
 If interactive mode is enabled, which it is per-default, then you will be
 prompted to fill in the fields of the changelog as well as a larger free-form

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,7 +77,7 @@ pub enum Command {
     CreateRelease(VersionSpec),
 
     /// Generate the changelog file from the fragments marked for release
-    Release {
+    GenerateChangelog {
         /// Also write "unreleased" stuff to the CHANGELOG.md file
         #[clap(long)]
         all: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ pub enum Command {
     Init,
 
     /// Create a new changelog fragment
-    New {
+    Add {
         #[clap(short, long, action = clap::ArgAction::Set, default_value_t = true)]
         interactive: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,7 @@ pub enum Command {
     /// Use the current unreleased changelog fragments to generate the changelog for the next
     /// release
     #[clap(subcommand)]
-    Generate(VersionSpec),
+    CreateRelease(VersionSpec),
 
     /// Generate the changelog file from the fragments marked for release
     Release {

--- a/src/command/add_command.rs
+++ b/src/command/add_command.rs
@@ -22,7 +22,7 @@ use crate::fragment::FragmentDataType;
 use crate::fragment::FragmentDataTypeDefinite;
 
 #[derive(Debug, typed_builder::TypedBuilder)]
-pub struct NewCommand {
+pub struct AddCommand {
     interactive: bool,
     edit: bool,
     format: Format,
@@ -31,7 +31,7 @@ pub struct NewCommand {
     git: Option<GitSetting>,
 }
 
-impl crate::command::Command for NewCommand {
+impl crate::command::Command for AddCommand {
     fn execute(self, workdir: &Path, config: &Configuration) -> Result<(), Error> {
         let unreleased_dir_path = ensure_fragment_dir(workdir, config)?;
 

--- a/src/command/create_release_command.rs
+++ b/src/command/create_release_command.rs
@@ -5,11 +5,11 @@ use crate::{
 };
 
 #[derive(Debug, typed_builder::TypedBuilder)]
-pub struct GenerateCommand {
+pub struct CreateReleaseCommand {
     version: VersionSpec,
 }
 
-impl crate::command::Command for GenerateCommand {
+impl crate::command::Command for CreateReleaseCommand {
     fn execute(self, workdir: &Path, config: &Configuration) -> Result<(), Error> {
         let version_string = find_version_string(workdir, &self.version)?;
         log::debug!("Creating new directory for version '{}'", version_string);

--- a/src/command/generate_changelog_command.rs
+++ b/src/command/generate_changelog_command.rs
@@ -4,13 +4,13 @@ use std::{collections::HashMap, io::BufReader, path::Path};
 use crate::{config::Configuration, error::Error, fragment::Fragment};
 
 #[derive(typed_builder::TypedBuilder)]
-pub struct ReleaseCommand {
+pub struct GenerateChangelogCommand {
     repository: git2::Repository,
     all: bool,
     allow_dirty: bool,
 }
 
-impl std::fmt::Debug for ReleaseCommand {
+impl std::fmt::Debug for GenerateChangelogCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReleaseCommand")
             .field("repository", &self.repository.workdir())
@@ -20,7 +20,7 @@ impl std::fmt::Debug for ReleaseCommand {
     }
 }
 
-impl crate::command::Command for ReleaseCommand {
+impl crate::command::Command for GenerateChangelogCommand {
     fn execute(self, workdir: &Path, config: &Configuration) -> Result<(), Error> {
         if crate::util::repo_is_dirty(&self.repository) && !self.allow_dirty {
             return Err(Error::GitRepoDirty);

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -4,8 +4,8 @@ use crate::config::Configuration;
 
 mod common;
 
-mod new_command;
-pub use self::new_command::NewCommand;
+mod add_command;
+pub use self::add_command::AddCommand;
 
 mod generate_command;
 pub use self::generate_command::GenerateCommand;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -10,9 +10,9 @@ pub use self::add_command::AddCommand;
 mod create_release_command;
 pub use self::create_release_command::CreateReleaseCommand;
 
-mod release_command;
-pub use self::release_command::ReleaseCommand;
-pub use self::release_command::VersionData;
+mod generate_changelog_command;
+pub use self::generate_changelog_command::GenerateChangelogCommand;
+pub use self::generate_changelog_command::VersionData;
 
 mod show;
 pub use self::show::Show;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -7,8 +7,8 @@ mod common;
 mod add_command;
 pub use self::add_command::AddCommand;
 
-mod generate_command;
-pub use self::generate_command::GenerateCommand;
+mod create_release_command;
+pub use self::create_release_command::CreateReleaseCommand;
 
 mod release_command;
 pub use self::release_command::ReleaseCommand;

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,14 +56,14 @@ fn main() -> miette::Result<()> {
     match args.command {
         Command::Init => unreachable!(), // reached above
 
-        Command::New {
+        Command::Add {
             interactive,
             edit,
             format,
             read,
             set,
             git,
-        } => crate::command::NewCommand::builder()
+        } => crate::command::AddCommand::builder()
             .interactive(interactive)
             .edit(edit)
             .format(format)

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,12 +82,14 @@ fn main() -> miette::Result<()> {
             .build()
             .execute(&repo_workdir_path, &config)?,
 
-        Command::Release { all, allow_dirty } => crate::command::ReleaseCommand::builder()
-            .repository(repository)
-            .all(all)
-            .allow_dirty(allow_dirty)
-            .build()
-            .execute(&repo_workdir_path, &config)?,
+        Command::GenerateChangelog { all, allow_dirty } => {
+            crate::command::GenerateChangelogCommand::builder()
+                .repository(repository)
+                .all(all)
+                .allow_dirty(allow_dirty)
+                .build()
+                .execute(&repo_workdir_path, &config)?
+        }
 
         Command::Show { format, range } => crate::command::Show::builder()
             .format(format)

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> miette::Result<()> {
             .build()
             .execute(&repo_workdir_path, &config)?,
 
-        Command::Generate(version) => crate::command::GenerateCommand::builder()
+        Command::CreateRelease(version) => crate::command::CreateReleaseCommand::builder()
             .version(version)
             .build()
             .execute(&repo_workdir_path, &config)?,

--- a/tests/add_command.rs
+++ b/tests/add_command.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 mod common;
 
 #[test]
-fn new_command_creates_toml_file() {
+fn add_command_creates_toml_file() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
@@ -11,7 +11,7 @@ fn new_command_creates_toml_file() {
     self::common::init_git(temp_dir.path());
     self::common::init_cargo_changelog(temp_dir.path());
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",
@@ -76,7 +76,7 @@ fn new_command_creates_toml_file() {
 }
 
 #[test]
-fn new_command_creates_unreleased_gitkeep() {
+fn add_command_creates_unreleased_gitkeep() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
@@ -98,7 +98,7 @@ fn new_command_creates_unreleased_gitkeep() {
 }
 
 #[test]
-fn new_command_with_text_creates_toml_with_text_from_stdin() {
+fn add_command_with_text_creates_toml_with_text_from_stdin() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
@@ -124,7 +124,7 @@ fn new_command_with_text_creates_toml_with_text_from_stdin() {
         file.sync_all().unwrap();
         drop(file); // make sure we close the handle
 
-        self::common::cargo_changelog_new(temp_dir.path())
+        self::common::cargo_changelog_add(temp_dir.path())
             .args([
                 "--format=toml",
                 "--set",
@@ -164,7 +164,7 @@ fn new_command_with_text_creates_toml_with_text_from_stdin() {
 }
 
 #[test]
-fn new_command_with_text_creates_toml_with_text_from_file() {
+fn add_command_with_text_creates_toml_with_text_from_file() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
@@ -190,7 +190,7 @@ fn new_command_with_text_creates_toml_with_text_from_file() {
         file.sync_all().unwrap();
         drop(file); // make sure we close the handle
 
-        self::common::cargo_changelog_new(temp_dir.path())
+        self::common::cargo_changelog_add(temp_dir.path())
             .args([
                 "--format=toml",
                 "--set",
@@ -232,7 +232,7 @@ fn new_command_with_text_creates_toml_with_text_from_file() {
 }
 
 #[test]
-fn new_command_creates_toml_header() {
+fn add_command_creates_toml_header() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
@@ -240,7 +240,7 @@ fn new_command_creates_toml_header() {
     self::common::init_git(temp_dir.path());
     self::common::init_cargo_changelog(temp_dir.path());
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",
@@ -282,7 +282,7 @@ fn new_command_creates_toml_header() {
 }
 
 #[test]
-fn new_command_cannot_create_nonexistent_oneof() {
+fn add_command_cannot_create_nonexistent_oneof() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
@@ -306,7 +306,7 @@ fn new_command_cannot_create_nonexistent_oneof() {
         file.sync_all().unwrap()
     }
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",

--- a/tests/add_command_creates_default_header.rs
+++ b/tests/add_command_creates_default_header.rs
@@ -31,7 +31,7 @@ fn new_command_creates_default_header() {
         file.sync_all().unwrap()
     }
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",

--- a/tests/add_command_editor.rs
+++ b/tests/add_command_editor.rs
@@ -9,7 +9,7 @@ mod common;
 // We create a shell script that "edits" a file by creating a file next to it with the same name +
 // ".edited".
 //
-// We set this script as EDITOR and VISUAL and then execute the "new" command. If the test sees the
+// We set this script as EDITOR and VISUAL and then execute the "add" command. If the test sees the
 // "*.edited" file, it knows that the editor was called
 //
 
@@ -18,7 +18,7 @@ touch "${1}.edited"
 "#;
 
 #[test]
-fn new_command_opens_editor() {
+fn add_command_opens_editor() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
@@ -28,7 +28,7 @@ fn new_command_opens_editor() {
 
     let (script_temp_dir, editor_script_path) = {
         let temp = tempfile::Builder::new()
-            .prefix("cargo-changelog-new-editor-script-helper")
+            .prefix("cargo-changelog-add-editor-script-helper")
             .tempdir()
             .unwrap();
         let script_path = temp.path().join("editor");
@@ -71,7 +71,7 @@ fn new_command_opens_editor() {
             .into_iter(),
         )
         .args([
-            "new",
+            "add",
             "--interactive=false",
             "--format=toml",
             "--set",

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -39,9 +39,9 @@ pub fn cargo_changelog_cmd(dir: &std::path::Path) -> assert_cmd::Command {
     cmd
 }
 
-pub fn cargo_changelog_new(dir: &std::path::Path) -> assert_cmd::Command {
+pub fn cargo_changelog_add(dir: &std::path::Path) -> assert_cmd::Command {
     let mut cmd = cargo_changelog_cmd(dir);
-    cmd.arg("new");
+    cmd.arg("add");
     cmd.arg("--interactive");
     cmd.arg("false");
     cmd.arg("--edit");

--- a/tests/generate_command.rs
+++ b/tests/generate_command.rs
@@ -43,7 +43,7 @@ fn generate_command_moves_from_unreleased_dir() {
     self::common::init_cargo(temp_dir.path(), "cargo-changelog-testpkg-generatecommand");
     self::common::init_cargo_changelog(temp_dir.path());
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",

--- a/tests/generate_command.rs
+++ b/tests/generate_command.rs
@@ -5,13 +5,16 @@ use assert_cmd::Command;
 mod common;
 
 #[test]
-fn generate_command_creates_new_directory() {
+fn create_release_command_creates_new_directory() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
         .unwrap();
     self::common::init_git(temp_dir.path());
-    self::common::init_cargo(temp_dir.path(), "cargo-changelog-testpkg-generatecommand");
+    self::common::init_cargo(
+        temp_dir.path(),
+        "cargo-changelog-testpkg-create-release_command",
+    );
     self::common::init_cargo_changelog(temp_dir.path());
 
     let unreleased_dir = temp_dir.path().join(".changelogs").join("unreleased");
@@ -19,10 +22,10 @@ fn generate_command_creates_new_directory() {
         panic!("Unreleased directory does not exist");
     }
 
-    // call `cargo-changelog generate`
+    // call `cargo-changelog create-release`
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["generate", "minor"])
+        .args(["create-release", "minor"])
         .current_dir(&temp_dir)
         .assert()
         .success();
@@ -34,13 +37,16 @@ fn generate_command_creates_new_directory() {
 }
 
 #[test]
-fn generate_command_moves_from_unreleased_dir() {
+fn create_release_command_moves_from_unreleased_dir() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
         .unwrap();
     self::common::init_git(temp_dir.path());
-    self::common::init_cargo(temp_dir.path(), "cargo-changelog-testpkg-generatecommand");
+    self::common::init_cargo(
+        temp_dir.path(),
+        "cargo-changelog-testpkg-create-release_command",
+    );
     self::common::init_cargo_changelog(temp_dir.path());
 
     self::common::cargo_changelog_add(temp_dir.path())
@@ -80,10 +86,10 @@ fn generate_command_moves_from_unreleased_dir() {
         panic!("Release directory should not exist yet");
     }
 
-    // call `cargo-changelog generate`
+    // call `cargo-changelog create-release`
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["generate", "minor"])
+        .args(["create-release", "minor"])
         .current_dir(&temp_dir)
         .assert()
         .success();

--- a/tests/no_config_error.rs
+++ b/tests/no_config_error.rs
@@ -12,7 +12,7 @@ fn no_configuration_file_errors() {
 
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["release"]) // we need some subcommand, otherwise nothing happens
+        .args(["generate-changelog"]) // we need some subcommand, otherwise nothing happens
         .current_dir(&temp_dir)
         .assert()
         .failure();
@@ -28,7 +28,7 @@ fn no_configuration_file_errors_with_error_message() {
 
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["release"]) // we need some subcommand, otherwise nothing happens
+        .args(["generate-changelog"]) // we need some subcommand, otherwise nothing happens
         .current_dir(&temp_dir)
         .assert()
         .stderr(predicates::str::contains(

--- a/tests/no_repo_error.rs
+++ b/tests/no_repo_error.rs
@@ -9,7 +9,7 @@ fn no_repo_errors() {
 
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["release"]) // we need some subcommand, otherwise nothing happens
+        .args(["generate-changelog"]) // we need some subcommand, otherwise nothing happens
         .current_dir(&temp_dir)
         .assert()
         .failure();
@@ -24,7 +24,7 @@ fn no_repo_errors_with_no_repo_error_message() {
 
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["release"]) // we need some subcommand, otherwise nothing happens
+        .args(["generate-changelog"]) // we need some subcommand, otherwise nothing happens
         .current_dir(&temp_dir)
         .assert()
         .stderr(predicates::str::contains("could not find repository"));

--- a/tests/release_command.rs
+++ b/tests/release_command.rs
@@ -5,13 +5,13 @@ use assert_cmd::Command;
 mod common;
 
 #[test]
-fn release_command_works() {
+fn generate_changelog_command_works() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
         .unwrap();
     self::common::init_git(temp_dir.path());
-    self::common::init_cargo(temp_dir.path(), "release_command_works");
+    self::common::init_cargo(temp_dir.path(), "generate_changelog_command_works");
     self::common::init_cargo_changelog(temp_dir.path());
 
     self::common::cargo_changelog_add(temp_dir.path())
@@ -37,7 +37,7 @@ fn release_command_works() {
     // call `cargo-changelog create-release`
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["release"])
+        .args(["generate-changelog"])
         .current_dir(&temp_dir)
         .assert()
         .success();
@@ -53,13 +53,16 @@ fn release_command_works() {
 }
 
 #[test]
-fn release_command_works_for_alpha_release() {
+fn generate_changelog_command_works_for_alpha_release() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
         .unwrap();
     self::common::init_git(temp_dir.path());
-    self::common::init_cargo(temp_dir.path(), "release_command_works_for_alpha_release");
+    self::common::init_cargo(
+        temp_dir.path(),
+        "generate_changelog_command_works_for_alpha_release",
+    );
     self::common::init_cargo_changelog(temp_dir.path());
 
     self::common::cargo_changelog_add(temp_dir.path())
@@ -109,7 +112,7 @@ fn release_command_works_for_alpha_release() {
     // call `cargo-changelog create-release`
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["release"])
+        .args(["generate-changelog"])
         .current_dir(&temp_dir)
         .assert()
         .success();
@@ -129,13 +132,16 @@ fn release_command_works_for_alpha_release() {
 }
 
 #[test]
-fn release_command_works_with_suffix() {
+fn generate_changelog_command_works_with_suffix() {
     let temp_dir = tempfile::Builder::new()
         .prefix("cargo-changelog")
         .tempdir()
         .unwrap();
     self::common::init_git(temp_dir.path());
-    self::common::init_cargo(temp_dir.path(), "release_command_works_with_suffix");
+    self::common::init_cargo(
+        temp_dir.path(),
+        "generate_changelog_command_works_with_suffix",
+    );
     self::common::init_cargo_changelog(temp_dir.path());
 
     self::common::cargo_changelog_add(temp_dir.path())
@@ -197,7 +203,7 @@ fn release_command_works_with_suffix() {
 
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["release"])
+        .args(["generate-changelog"])
         .current_dir(&temp_dir)
         .assert()
         .success();

--- a/tests/release_command.rs
+++ b/tests/release_command.rs
@@ -29,12 +29,12 @@ fn release_command_works() {
 
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["generate", "minor"])
+        .args(["create-release", "minor"])
         .current_dir(&temp_dir)
         .assert()
         .success();
 
-    // call `cargo-changelog generate`
+    // call `cargo-changelog create-release`
     Command::cargo_bin("cargo-changelog")
         .unwrap()
         .args(["release"])
@@ -101,12 +101,12 @@ fn release_command_works_for_alpha_release() {
 
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["generate", "custom", "0.1.0-alpha.1"])
+        .args(["create-release", "custom", "0.1.0-alpha.1"])
         .current_dir(&temp_dir)
         .assert()
         .success();
 
-    // call `cargo-changelog generate`
+    // call `cargo-changelog create-release`
     Command::cargo_bin("cargo-changelog")
         .unwrap()
         .args(["release"])
@@ -190,7 +190,7 @@ fn release_command_works_with_suffix() {
 
     Command::cargo_bin("cargo-changelog")
         .unwrap()
-        .args(["generate", "custom", "0.1.0-alpha.1"])
+        .args(["create-release", "custom", "0.1.0-alpha.1"])
         .current_dir(&temp_dir)
         .assert()
         .success();

--- a/tests/release_command.rs
+++ b/tests/release_command.rs
@@ -14,7 +14,7 @@ fn release_command_works() {
     self::common::init_cargo(temp_dir.path(), "release_command_works");
     self::common::init_cargo_changelog(temp_dir.path());
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",
@@ -62,7 +62,7 @@ fn release_command_works_for_alpha_release() {
     self::common::init_cargo(temp_dir.path(), "release_command_works_for_alpha_release");
     self::common::init_cargo_changelog(temp_dir.path());
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",
@@ -138,7 +138,7 @@ fn release_command_works_with_suffix() {
     self::common::init_cargo(temp_dir.path(), "release_command_works_with_suffix");
     self::common::init_cargo_changelog(temp_dir.path());
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",

--- a/tests/verify_metadata_command.rs
+++ b/tests/verify_metadata_command.rs
@@ -28,7 +28,7 @@ fn verify_metadata_command_succeeds_with_empty_changelog() {
     self::common::init_git(temp_dir.path());
     self::common::init_cargo_changelog(temp_dir.path());
 
-    self::common::cargo_changelog_new(temp_dir.path())
+    self::common::cargo_changelog_add(temp_dir.path())
         .args([
             "--format=toml",
             "--set",


### PR DESCRIPTION
This solves #229 

Current help output:

```
Commands:
  init                Initialize the repository for cargo-changelog
  add                 Create a new changelog fragment
  verify-metadata     Verify the metadata in existing changelog fragments
  create-release      Use the current unreleased changelog fragments to generate the changelog for the next release
  generate-changelog  Generate the changelog file from the fragments marked for release
  show
  help                Print this message or the help of the given subcommand(s)
```
