### PR TITLE
Fix: Ask for data for non-required keys

### DIFF
--- a/.changelogs/unreleased/2023-06-18T13_57_52_335292453.md
+++ b/.changelogs/unreleased/2023-06-18T13_57_52_335292453.md
@@ -1,0 +1,9 @@
++++
+issue = 248
+subject = "Ask for non-required keys"
+type = "Bugfix"
++++
+
+If a header-field was not required, cargo-changelog did not ask for it.
+Now it asks whether the user wants to provide a value for it, and if yes, it
+asks for the value.


### PR DESCRIPTION
This patch fixes the issue that non-required keys were not asked for in interactive mode.
Now we ask whether the user wants to provide a value for a non-required key and if yes, we ask them for the value.

---

Closes #248 