### PR TITLE
Don't output quotes for groups

### DIFF
--- a/.changelogs/unreleased/2025-07-17T09_33_48_715921239.md
+++ b/.changelogs/unreleased/2025-07-17T09_33_48_715921239.md
@@ -1,0 +1,6 @@
++++
+subject = "Don't quote group keys"
+type = "Bugfix"
++++
+
+Previously group keys would appear quoted. They no longer do.

--- a/src/template/group_by_helper.rs
+++ b/src/template/group_by_helper.rs
@@ -54,7 +54,7 @@ impl HelperDef for GroupByHelper {
                     .into_grouping_map_by(|elt: &serde_json::Value| {
                         elt.get("header")
                             .and_then(|hdr| hdr.get(group_by_attr))
-                            .cloned()
+                            .and_then(|v| v.as_str().map(ToString::to_string))
                     })
                     .collect::<Vec<_>>()
                 {


### PR DESCRIPTION
Per default serde_json::Value adds quotes around strings (cause thats how they are represented in JSON). We extract them here first.